### PR TITLE
Support for Markdown Preprocessor (MarkdownPP)

### DIFF
--- a/grammars/pfm.cson
+++ b/grammars/pfm.cson
@@ -10,6 +10,7 @@ fileTypes: [
   'ron'
   'pmd'
   'p.md'
+  'mdpp'
 ]
 patterns: [
   {


### PR DESCRIPTION
The additional extension `mdpp` highlights Markdown files supposed to be used and combined by https://github.com/jreese/markdown-pp
