### PR TITLE
Fixed  scopeName

### DIFF
--- a/grammars/pfm.cson
+++ b/grammars/pfm.cson
@@ -1,5 +1,5 @@
 name: 'Pandoc Markdown'
-scopeName: 'source.gfm'
+scopeName: 'source.pfm'
 fileTypes: [
   'markdown'
   'md'


### PR DESCRIPTION
This scope should be `source.pfm` since `source.gfm` is related to GitHub Flavored Markdown. Probably you missed the change when forking?